### PR TITLE
fix_lb_port_forward

### DIFF
--- a/concourse-web-svc.yaml
+++ b/concourse-web-svc.yaml
@@ -4,9 +4,14 @@ metadata:
   name: concourse-web
 spec:
   ports:
-  - port: 8080
+  - name: http
+    port: 8080
     protocol: 'TCP'
     targetPort: 8080
+  - name: ssh
+    port: 2222
+    protocol: 'TCP'
+    targetPort: 2222
   selector:
     name: concourse-web
   type: LoadBalancer


### PR DESCRIPTION
This PR suggests a fix to an error we're getting where a worker fail the following way :
`{"timestamp":"1475780538.338568926","source":"worker","message":"worker.beacon.restarting","log_level":2,"data":{"error":"failed to dial: failed to connect to TSA:%!(EXTRA *net.OpError=dial tcp: too many colons in address XXX.XXX.XXX.XXX:8080:2222)","session":"3"}}`

It seems the port is hardcoded in the upstream Dockerfile and the exported `$(CONCOURSE_WEB_SERVICE_PORT)` variable doesn't override that value as expected.

Currently, loading those files in Kubernetes v1.4.0 doesn't work. This fix allows the ssh calls from the workers to traverse the service loadBalancer to reach the TSA.

More information can be found in the [issue](https://github.com/ls-avanier/concourse-kubernetes/issues/1) I opened in my fork.
